### PR TITLE
ci: add copilot guidance and automation workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners
+* @local-ai/maintainers

--- a/.github/coderabbit.yml
+++ b/.github/coderabbit.yml
@@ -1,0 +1,9 @@
+# Configuration for CoderabbitAI PR reviews
+version: 1
+review:
+  enabled: true
+  reviewers:
+    - coderabbitai
+  rules:
+    - match: '*'
+      actions: [comment, suggest]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+frontend:
+  - frontend/**
+backend:
+  - services/**
+  - mcp-servers/**
+docs:
+  - '**/*.md'
+workflows:
+  - .github/workflows/**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Pull Request
+
+## Summary
+- 
+
+## Testing
+- [ ] `uv run pytest`
+- [ ] `pre-commit run --files <files>`
+
+## Checklist
+- [ ] Documentation updated
+- [ ] Linked related issues
+- [ ] CoderabbitAI review complete

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,17 @@
+name: Add to Project
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/orgs/OWNER/projects/1
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          # Update project-url and provide PROJECT_TOKEN with project write access

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-message: 'This issue has been automatically marked as stale due to inactivity.'
+          close-issue-message: 'Closing this issue after prolonged inactivity.'
+          stale-pr-message: 'This pull request has been automatically marked as stale due to inactivity.'
+          close-pr-message: 'Closing this pull request after prolonged inactivity.'

--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -1,0 +1,16 @@
+name: TODO to Issue
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  convert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Convert TODOs to issues
+        uses: alstr/todo-to-issue-action@v0.9.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-assigned: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project adheres to the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+By participating, you are expected to uphold this code. Please report unacceptable behavior to the maintainers.

--- a/DIFF_20250914_070440.md
+++ b/DIFF_20250914_070440.md
@@ -1,0 +1,7 @@
+## Changes on 2025-09-14 07:04:40 UTC
+- Added repository-wide Copilot guidelines in `copilot-instructions.md`.
+- Introduced PR template to standardize submissions and integrate CoderabbitAI.
+- Added CoderabbitAI configuration via `.github/coderabbit.yml`.
+- Defined default code owners in `.github/CODEOWNERS`.
+- Established community standards with `CODE_OF_CONDUCT.md`.
+- Expanded `extensions.yml` to declare Copilot instructions and enable CoderabbitAI PR review.

--- a/DIFF_20250914_071811.md
+++ b/DIFF_20250914_071811.md
@@ -1,0 +1,7 @@
+# Changes on 2025-09-14 at 07:18:11 UTC
+
+- Added `.github/workflows/todo-to-issue.yml` to open issues from TODO comments.
+- Added `.github/workflows/add-to-project.yml` to automatically place issues and PRs on a project board.
+- Added `.github/workflows/stale.yml` to mark and close inactive issues and pull requests.
+- Added `.github/labeler.yml` to apply labels based on modified paths.
+- Extended `copilot-instructions.md` with automation details.

--- a/RECOMMENDATIONS_20250914_070440.md
+++ b/RECOMMENDATIONS_20250914_070440.md
@@ -1,0 +1,5 @@
+## Recommendations noted on 2025-09-14 07:04:40 UTC
+- Specify actual GitHub usernames in `.github/CODEOWNERS`.
+- Provide project-specific reviewer rules in `.github/coderabbit.yml` once team preferences are known.
+- Link this repository to a GitHub remote so automated issue creation and other integrations can function.
+- Consider adding dependency and security update workflows (e.g., Dependabot).

--- a/RECOMMENDATIONS_20250914_071811.md
+++ b/RECOMMENDATIONS_20250914_071811.md
@@ -1,0 +1,5 @@
+# Recommendations on 2025-09-14 at 07:18:11 UTC
+
+- Set the `project-url` in `.github/workflows/add-to-project.yml` and supply a token in `PROJECT_TOKEN` with project write access.
+- Expand `.github/labeler.yml` with additional path-label mappings as the codebase grows.
+- Monitor the `stale.yml` schedule and messaging to ensure it matches community expectations.

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,0 +1,33 @@
+# Copilot Instructions for Local AI Packaged
+
+This repository hosts the local-ai-packaged project. GitHub Copilot and similar tools should follow these guidelines when contributing code or documentation.
+
+## Project Conventions
+- **Language & Runtime:** Python 3.10. Use the `uv` package manager and work within the existing virtual environment.
+- **Code Style:** Follow PEP 8 and include type hints where practical.
+- **Documentation:** Update relevant Markdown files and docstrings when behavior changes.
+- **Secrets:** Never commit secrets or credentials.
+
+## Workflow Expectations
+1. Keep changes small and focused.
+2. Run `pre-commit run --files <changed files>` before committing.
+3. Execute `uv run pytest` and ensure tests pass.
+4. Include a concise summary in commit messages.
+
+## Pull Requests
+- Reference related issues.
+- Ensure the PR description outlines testing steps and any follow-up tasks.
+- CoderabbitAI and other review bots are enabled; allow them to complete reviews before merging.
+
+## Helpful Context
+- Service configurations live under `supabase`, `traefik`, and `monitoring`.
+- Frontend code is in `frontend` and Python services in `services`.
+- Workflows reside in `.github/workflows`.
+
+
+## Automation
+- TODO comments are converted to GitHub issues via a scheduled workflow.
+- New issues and pull requests are added to the project board automatically.
+- Stale issues and pull requests close after extended inactivity.
+
+By adhering to these instructions, Copilot can generate contributions aligned with repository standards.

--- a/extensions.yml
+++ b/extensions.yml
@@ -1,1 +1,4 @@
-{}
+coderabbitai:
+  pr_review: true
+copilot:
+  instructions: copilot-instructions.md


### PR DESCRIPTION
## Summary
- add repository-specific Copilot instructions
- set up PR template, Coderabbit config, and code owners
- document community standards with code of conduct
- automate issue management with TODO scanning, project syncing, stale cleanup, and path-based labels

## Testing
- `uv run pre-commit run --files .github/labeler.yml .github/workflows/add-to-project.yml .github/workflows/stale.yml .github/workflows/todo-to-issue.yml copilot-instructions.md DIFF_20250914_071811.md RECOMMENDATIONS_20250914_071811.md` *(fails: Unable to determine which files to ship)*
- `uv run pytest` *(fails: Unable to determine which files to ship)*
- `gh issue create -t "Automated test issue" -b "Testing issue creation"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c668aabb44832aaa3cec555be49158